### PR TITLE
Added blockinfo fields to UserInfo

### DIFF
--- a/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
@@ -11,14 +11,25 @@ public class UserInfo {
     private String name;
     private int id;
 
+    //Block information
+    private int blockid;
+    private String blockedby;
+    private int blockedbyid;
+    private String blockreason;
+    private String blocktimestamp;
+    private String blockexpiry;
+
     // Object type is any JSON type.
-    @Nullable private Map<String, ?> options;
+    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+    @Nullable
+    private Map<String, ?> options;
 
     public int id() {
         return id;
     }
 
-    @NonNull public Map<String, String> userjsOptions() {
+    @NonNull
+    public Map<String, String> userjsOptions() {
         Map<String, String> map = new HashMap<>();
         if (options != null) {
             for (Map.Entry<String, ?> entry : options.entrySet()) {
@@ -29,5 +40,29 @@ public class UserInfo {
             }
         }
         return map;
+    }
+
+    public int blockid() {
+        return blockid;
+    }
+
+    public String blockedby() {
+        return blockedby;
+    }
+
+    public int blockedbyid() {
+        return blockedbyid;
+    }
+
+    public String blockreason() {
+        return blockreason;
+    }
+
+    public String blocktimestamp() {
+        return blocktimestamp;
+    }
+
+    public String blockexpiry() {
+        return blockexpiry;
     }
 }


### PR DESCRIPTION
As a part of [commons-app/apps-android-commons#3026](https://github.com/commons-app/apps-android-commons/issues/3026) I am migrating ban detection to this library. However, the UserInfo class doesn't contain fields for uiprop=blockinfo. This PR adds the fields `blockid`, `blockedby`, `blockedbyid`, `blockreason`, `blocktimestamp `and `blockexpiry`. [Example query](https://commons.wikimedia.org/w/api.php?action=query&meta=userinfo&uiprop=blockinfo)